### PR TITLE
Add .git to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ config.json
 streamers.json
 docker-compose.yml
 actual-steamer.png
+.git


### PR DESCRIPTION
When only some git data like remotes, origin or refs are changed the Docker Image needs ne rebuild.