### PR TITLE
+ Ability to set priority channels and to always watch top streamer

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,9 @@ const maxWatching = (Number(process.env.maxWatching) || 30); //Minutes
 const streamerListRefresh = (Number(process.env.streamerListRefresh) || 1);
 const streamerListRefreshUnit = (process.env.streamerListRefreshUnit || 'hour'); //https://day.js.org/docs/en/manipulate/add
 
+const channelsWithPriority = process.env.channelsWithPriority ? process.env.channelsWithPriority.split(",") : [];
+const watchAlwaysTopStreamer = (process.env.watchAlwaysTopStreamer || false);
+
 const showBrowser = false; // false state equ headless mode;
 const proxy = (process.env.proxy || ""); // "ip:port" By https://github.com/Jan710
 const proxyAuth = (process.env.proxyAuth || "");
@@ -79,7 +82,22 @@ async function viewRandomPage(browser, page) {
         streamer_last_refresh = dayjs().add(streamerListRefresh, streamerListRefreshUnit); //https://github.com/D3vl0per/Valorant-watcher/issues/25
       }
 
-      let watch = streamers[getRandomInt(0, streamers.length - 1)]; //https://github.com/D3vl0per/Valorant-watcher/issues/27
+      let watch;
+
+      if (watchAlwaysTopStreamer) {
+          watch = streamers[0];
+      } else {
+          watch = streamers[getRandomInt(0, streamers.length - 1)]; //https://github.com/D3vl0per/Valorant-watcher/issues/27
+      }
+
+      if (channelsWithPriority.length > 0 ) {
+          for (let i = 0; i < channelsWithPriority.length; i++) {
+              if (streamers.includes(channelsWithPriority[i])) {
+                  watch = channelsWithPriority[i];
+                  break;
+             }
+         }
+      }
       var sleep = getRandomInt(minWatching, maxWatching) * 60000; //Set watuching timer
 
       console.log('\n🔗 Now watching streamer: ', baseUrl + watch);

--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -7,6 +7,9 @@ services:
     restart: always
     environment:
       - token=rxk38rh5qtyw95fkvm7kgfceh4mh6u #Example value from readme
+      #- streamersUrl=https://www.twitch.tv/directory/game/Rust?sort=VIEWER_COUNT&tl=c2542d6d-cd10-4532-919b-3d19f30a768b
+      #- watchAlwaysTopStreamer=true
+      #- channelsWithPriority=illojuan,alexby11,aroyitt
       #- userAgent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
       #- scrollDelay=2000
       #- scrollTimes=5


### PR DESCRIPTION
docker-composer.yaml new env vars example:
```
      - watchAlwaysTopStreamer=true
      - channelsWithPriority=illojuan,alexby11,aroyitt
```

Having both vars set, the app will prioritize the channels and then the top streamer. It's a good fallback as usually the top streamer has drops enabled too.

If user updates the channel list, he will have to run:
`docker-compose up -d valorant-watcher`

In order to recreate the container.