### PR TITLE
= Set version to 2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valorant-watcher",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Automatic watching the twitch to get valorant drop",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
It seems that DockerHub build didn't get triggered for latest update, so new features & fixes aren't yet available as @RFBomb reports here https://github.com/D3vl0per/Twitch-watcher/pull/84#issuecomment-778650819

Is there anything else that needs to be updated to trigger the build @D3vl0per?